### PR TITLE
fix: clean plugin paths in container to avoid host-container path conflicts

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,7 +115,7 @@ services:
     command:
       - "sh"
       - "-c"
-      - "cp -rn /home/node/.openclaw-seed/* /home/node/.openclaw/ 2>/dev/null || true && chown -R node:node /home/node/.openclaw && node dist/index.js config set gateway.controlUi.allowedOrigins '[\"http://127.0.0.1:18789\"]' --strict-json && node dist/index.js gateway --bind lan --port 18789"
+      - "cp -rn /home/node/.openclaw-seed/* /home/node/.openclaw/ 2>/dev/null || true && jq 'del(.plugins.load.paths) | del(.plugins.installs)' /home/node/.openclaw/openclaw.json > /tmp/openclaw.json 2>/dev/null && mv /tmp/openclaw.json /home/node/.openclaw/openclaw.json 2>/dev/null || true && chown -R node:node /home/node/.openclaw && node dist/index.js config set gateway.controlUi.allowedOrigins '[\"http://127.0.0.1:18789\"]' --strict-json && node dist/index.js gateway --bind lan --port 18789"
     healthcheck: &common-healthcheck
       test: [ "CMD", "node", "-e", "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))" ]
       interval: 30s
@@ -167,7 +167,7 @@ services:
     entrypoint:
       - "sh"
       - "-c"
-      - "cp -rn /home/node/.openclaw-seed/* /home/node/.openclaw/ 2>/dev/null || true && chown -R node:node /home/node/.openclaw && exec tail -f /dev/null"
+      - "cp -rn /home/node/.openclaw-seed/* /home/node/.openclaw/ 2>/dev/null || true && jq 'del(.plugins.load.paths) | del(.plugins.installs)' /home/node/.openclaw/openclaw.json > /tmp/openclaw.json 2>/dev/null && mv /tmp/openclaw.json /home/node/.openclaw/openclaw.json 2>/dev/null || true && chown -R node:node /home/node/.openclaw && exec tail -f /dev/null"
     labels:
       - "openclaw.service=cli"
       - "openclaw.environment=dev"


### PR DESCRIPTION
## Summary

This PR fixes plugin path resolution issues when running OpenClaw inside containers by removing host-specific plugin paths from `openclaw.json` during container initialization.

## Problem

When the container starts, it copies the host's OpenClaw configuration (including `openclaw.json`) to the container filesystem. However, the host's plugin paths (e.g., `plugins.load.paths`) may not exist or resolve correctly inside the container, causing plugin loading failures.

## Solution

Added a `jq` command to the container initialization process that strips out host-specific plugin configuration before starting services:

```bash
jq 'del(.plugins.load.paths) | del(.plugins.installs)' /home/node/.openclaw/openclaw.json
```

This ensures containers use their own plugin discovery mechanisms instead of inheriting potentially invalid host paths.

## Changes

- **openclaw-gateway**: Added jq cleanup to startup command
- **openclaw-cli**: Added jq cleanup to entrypoint script
- Both services now execute cleanup after config seed copy, before permission setup

## Testing

- ✅ YAML syntax validation passed
- ✅ Container initialization logic verified
- ✅ Compatible with new unified state volume architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)