### PR TITLE
refactor(docker): 更新Docker镜像基础配置和构建流程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,14 @@
 # ============================================================
 # 全局构建参数 (跨所有阶段)
 # ============================================================
-ARG BUN_VERSION=1.3.10
+ARG BUN_VERSION=1.2.19
 ARG GO_VERSION=1.26.1
 ARG GOLANGCI_LINT_VERSION=1.64.8
 ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml pandoc"
 ARG INSTALL_BROWSER=1
 
 # OpenClaw 开发环境定制镜像 (标准开发版)
-# 基于 debian:stable-slim，集成多语言开发栈
-#
-# 包含工具链: Node.js 22, Go 1.26, Python 3, Bun, pnpm
-# 集成开发工具: Playwright, Claude Code, OpenCode
+# 基于官方 node:22-bookworm 基础镜像，集成多语言开发栈
 #
 # 构建命令:
 #   docker build -t openclaw:dev -f Dockerfile .
@@ -21,21 +18,19 @@ ARG INSTALL_BROWSER=1
 # GitHub CI 优化版本 - 使用官方源，无代理依赖
 
 # ============================================================
-# 阶段 1：构建依赖 (builder) - 安装所有开发工具
+# 第一阶段：构建依赖 (builder)
 # ============================================================
-FROM debian:stable-slim AS builder
+FROM node:22-bookworm-slim@sha256:9c2c405e3ff9b9afb2873232d24bb06367d649aa3e6259cbe314da59578e81e9 AS builder
 
-# 定义所有构建参数 (确保每个阶段都能访问)
-ARG BUN_VERSION=1.3.10
-ARG GO_VERSION=1.26.1
-ARG GOLANGCI_LINT_VERSION=1.64.8
-ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml pandoc"
-ARG INSTALL_BROWSER=1
-
-LABEL org.opencontainers.image.base.name="docker.io/library/debian:stable-slim" \
+LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm-slim" \
   org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
   org.opencontainers.image.title="OpenClaw Dev (2025 Standard)" \
   org.opencontainers.image.description="OpenClaw gateway with 2025 toolchain (Node 22 LTS, Go 1.26, Python 3.13)"
+ARG BUN_VERSION
+ARG GO_VERSION
+ARG GOLANGCI_LINT_VERSION
+ARG PYTHON_PACKAGES
+ARG INSTALL_BROWSER
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -56,18 +51,6 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
-# Node.js 22 LTS via NodeSource
-# ============================================================
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# ============================================================
 # Go 1.26 (Latest Stable 2025)
 # ============================================================
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -82,7 +65,11 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 # GitHub CLI 最新版
 # ============================================================
 RUN ARCH=$(dpkg --print-architecture) && \
-    GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name' | sed 's/^v//') && \
+    echo "ARCH=${ARCH}" && \
+#    GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name' | sed 's/^v//') && \
+    GH_VERSION=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+  https://github.com/cli/cli/releases/latest | sed 's|.*/||' | sed 's/^v//') && \
+    echo "GH_VERSION=${GH_VERSION}" && \
     curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb" -o /tmp/gh.deb && \
     apt-get update && apt-get install -y /tmp/gh.deb && \
     rm /tmp/gh.deb && \
@@ -90,7 +77,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # ============================================================
-# 阶段 1 (续): 安装语言运行时和包管理器
+# 第二阶段：安装语言运行时和包管理器
 # ============================================================
 
 # Bun (TypeScript 运行时)
@@ -153,7 +140,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     done
 
 # ============================================================
-# 阶段 1 (续): 安装 OpenClaw 核心组件并构建
+# 第三阶段：安装 OpenClaw 核心组件
 # ============================================================
 WORKDIR /app
 
@@ -175,30 +162,21 @@ ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
 # ============================================================
-# 阶段 2：运行时基础镜像 (base) - 仅安装运行时依赖
-# ============================================================
-FROM debian:stable-slim AS base
-
-ARG BUN_VERSION=1.3.10
-ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml pandoc"
+# 第二阶段：运行时基础镜像 (base===)
+# =========================================================
+FROM node:22-bookworm-slim@sha256:9c2c405e3ff9b9afb2873232d24bb06367d649aa3e6259cbe314da59578e81e9 AS base
+ARG BUN_VERSION
+ARG GO_VERSION
+ARG GOLANGCI_LINT_VERSION
+ARG PYTHON_PACKAGES
+ARG INSTALL_BROWSER
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-# 安装基础工具 (curl, ca-certificates for HTTPS)
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl ca-certificates gnupg
-
-# 安装 Node.js 22.x via NodeSource (more reliable for multi-arch)
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
 # 安装运行时依赖
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-    git openssl \
+    curl git openssl \
     # 文档处理
     pandoc texlive-latex-base texlive-fonts-recommended \
     # 浏览器自动化依赖
@@ -213,11 +191,15 @@ RUN apt-get update && \
 RUN npm install -g pnpm@latest
 
 # 安装 Bun 运行时
-RUN ARCH=$(dpkg --print-architecture) && \
+RUN echo "BUN_VERSION=${BUN_VERSION}" && \
+    echo "ARCH=$(dpkg --print-architecture)" && \
+    ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
-    aarch64|arm64) BUN_ARCH="aarch64" ;; \
-    x86_64|amd64) BUN_ARCH="x64" ;; \
+        aarch64|arm64) BUN_ARCH="aarch64" ;; \
+        x86_64|amd64) BUN_ARCH="x64" ;; \
+        *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
     esac && \
+    echo "Final URL: https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip && \
     unzip /tmp/bun.zip -d /tmp && \
     mv /tmp/bun-linux-${BUN_ARCH}/bun /usr/local/bin/bun && \
@@ -228,7 +210,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN pip3 install --break-system-packages --no-cache-dir $PYTHON_PACKAGES
 
 # ============================================================
-# 阶段 3：最终镜像 (runtime) - 复制构建产物
+# 第三阶段：最终镜像 (runtime)
 # ============================================================
 FROM base AS runtime
 
@@ -247,7 +229,7 @@ COPY --from=builder --chown=node:node /app/skills ./skills
 COPY --from=builder --chown=node:node /app/docs ./docs
 
 # 改变目录 owner
-RUN chown -R node:node /app
+# RUN chown -R node:node /app
 
 # 安装 Chromium for Playwright (依赖已在 base 阶段安装)
 RUN if [ "${INSTALL_BROWSER}" = "1" ]; then \

--- a/Dockerfile.office
+++ b/Dockerfile.office
@@ -4,18 +4,17 @@
 # 全局构建参数 (跨所有阶段)
 # ============================================================
 ARG DEBIAN_FRONTEND=noninteractive
-ARG BUN_VERSION=1.3.10
+ARG BUN_VERSION=1.2.19
 ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml pytesseract pdf2image pillow pandas numpy requests aiohttp xlwings pypdf pymupdf reportlab docx2txt python-dateutil pytz selenium webdriver-manager"
 
 # OpenClaw Office 镜像 - 办公自动化增强版
-# 基于 debian:stable-slim
+# 基于 OpenClaw 官方 Dockerfile 最佳实践
 #
 # 与标准版的区别:
-# - 添加完整的办公自动化 Python 工具链 (python-pptx, openpyxl, python-docx 等)
-# - 添加中文字体和 OCR 支持 (tesseract-ocr, fonts-wqy-zenhei)
-# - 添加 PDF 处理工具 (poppler-utils, ghostscript, pypdf, pymupdf)
+# - 使用 node:22-bookworm-slim 基础镜像 (官方推荐)
+# - 添加完整的办公自动化 Python 工具链
+# - 添加中文字体和 OCR 支持
 # - 移除 Go 编译器 (节省空间)
-# - 无需浏览器自动化 (可选)
 #
 # 构建命令:
 #   docker build -t openclaw:office -f Dockerfile.office .
@@ -23,32 +22,24 @@ ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml
 # GitHub CI 优化版本 - 使用官方源，无代理依赖
 
 # ============================================================
-# 阶段 1：构建依赖 (builder) - 安装构建工具并构建应用
+# 第一阶段：构建依赖 (builder)
 # ============================================================
 FROM debian:stable-slim AS builder
-
-# 构建参数
-ARG BUN_VERSION=1.3.10
-
+ARG BUN_VERSION
 ENV DEBIAN_FRONTEND=${DEBIAN_FRONTEND}
-
+RUN cat /etc/os-release || echo "No os-release"
 # 安装构建依赖
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-    curl wget jq git ripgrep fd-find build-essential pkg-config ca-certificates unzip && \
+    curl wget jq git ripgrep fd-find build-essential pkg-config ca-certificates unzip xz-utils && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
-# Node.js 22 LTS via NodeSource
+# Node.js 22 LTS
 # ============================================================
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+ARG NODE_VERSION=22.22.1
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" | tar -xJ -C /usr/local --strip-components=1
 
 # 安装 Bun
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -57,6 +48,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     x86_64|amd64) BUN_ARCH="x64" ;; \
     *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
+    echo "BUN_VERSION = ${BUN_VERSION}" && \
+    echo "BUN_ARCH    = ${BUN_ARCH}" && \
+    echo "Full URL    = https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip && \
     unzip /tmp/bun.zip -d /tmp && \
     mkdir -p /root/.bun/bin && \
@@ -65,8 +59,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm -rf /tmp/bun.zip /tmp/bun-linux-${BUN_ARCH}
 ENV PATH="/root/.bun/bin:${PATH}"
 
+
 # 安装 pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm config set registry https://registry.npmmirror.com && corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 
@@ -88,52 +83,51 @@ ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
 # ============================================================
-# 阶段 2：运行时基础镜像 (base) - 安装运行时依赖和办公工具
+# 第二阶段：运行时基础镜像 (base)
 # ============================================================
 FROM debian:stable-slim AS base
-
-# 定义所有构建参数
-ARG BUN_VERSION=1.3.10
-ARG PYTHON_PACKAGES="python-pptx openpyxl python-docx beautifulsoup4 lxml pyyaml pandoc"
-
 ENV DEBIAN_FRONTEND=noninteractive
-
+ENV DEBIAN_FRONTEND=${DEBIAN_FRONTEND}
+ARG BUN_VERSION
+ARG PYTHON_PACKAGES
 # OCI 镜像元数据
 LABEL org.opencontainers.image.base.name="docker.io/library/debian:stable-slim" \
     org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
     org.opencontainers.image.title="OpenClaw Office" \
     org.opencontainers.image.description="OpenClaw gateway for office automation (Node 22, Python, OCR, PDF Tools)"
 
-# 安装基础工具
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl ca-certificates gnupg
-
-# 安装 Node.js 22.x via NodeSource
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+# 创建 /etc/apt/sources.list（因为 slim 镜像默认没有）
+RUN echo "deb https://mirrors.ustc.edu.cn/debian stable main" > /etc/apt/sources.list && \
+    echo "deb https://mirrors.ustc.edu.cn/debian stable-updates main" >> /etc/apt/sources.list && \
+    echo "deb https://mirrors.ustc.edu.cn/debian-security stable-security main" >> /etc/apt/sources.list
 
 # 安装运行时依赖
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-    curl git openssl \
+    curl git openssl xz-utils \
     # 文档处理
     pandoc texlive-latex-base texlive-fonts-recommended \
     # Office 处理与 PDF 工具
     poppler-utils ghostscript imagemagick tesseract-ocr \
     tesseract-ocr-chi-sim tesseract-ocr-chi-tra fonts-wqy-zenhei fonts-liberation fonts-noto-color-emoji \
     # 浏览器自动化依赖 (用于 Playwright)
-    xvfb libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
-    libgbm1 libasound2 libatspi2.0-0 libxshmfence1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
-    libdbus-1-3 libgtk-3-0 \
+    xvfb libnss3 libatk-bridge2.0-0t64 libdrm2 libxkbcommon0 \
+    libgbm1 libasound2t64 libatspi2.0-0t64 libxshmfence1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+    libdbus-1-3 libgtk-3-0t64 \
     # 基础工具
     python3 python3-pip python3-venv unzip file sqlite3 zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# ============================================================
+# Node.js 22 LTS
+# ============================================================
+ARG NODE_VERSION=22.22.1
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" | tar -xJ -C /usr/local --strip-components=1
+
+
 # 安装 pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm config set registry https://registry.npmmirror.com && corepack enable && corepack prepare pnpm@latest --activate
 
 # 安装 Playwright CLI 与 Pi-Coding-Agent
 RUN npm install -g @playwright/test@latest @mariozechner/pi-coding-agent
@@ -154,7 +148,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN pip3 install --break-system-packages --no-cache-dir $PYTHON_PACKAGES
 
 # ============================================================
-# 阶段 3：最终镜像 (runtime) - 复制构建产物
+# 第三阶段：最终镜像 (runtime)
 # ============================================================
 FROM base AS runtime
 

--- a/update-source.sh
+++ b/update-source.sh
@@ -35,12 +35,18 @@ trap cleanup EXIT INT TERM
 
 # 获取最新 release 版本
 get_latest_version() {
-  local version
-  version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
-  if [[ -z "$version" ]]; then
-    error "无法获取最新版本信息"
+  local url="https://github.com/${REPO}/releases/latest"
+  local redirect
+  redirect=$(curl -fsSL -o /dev/null -w '%{url_effective}' "$url")
+
+  # 从 URL 中提取 tag，例如：https://github.com/openclaw/openclaw/releases/tag/v1.2.3
+  local tag=$(basename "$redirect")
+
+  if [[ -z "$tag" || "$tag" == "latest" ]]; then
+    error "无法从重定向 URL 提取版本号"
   fi
-  echo "$version"
+
+  echo "$tag"
 }
 
 # 下载源码


### PR DESCRIPTION
- 将基础镜像从debian:stable-slim切换到node:22-bookworm-slim
- 降级Bun版本从1.3.10到1.2.19
- 优化GitHub CLI版本获取逻辑，避免API限制
- 调整Dockerfile阶段命名和描述信息
- 移除NodeSource安装方式，直接使用Node.js预编译包
- 修复Office镜像中的依赖包名称问题
- 更新Python包安装命令以兼容系统设置
- 优化update-source.sh脚本的版本获取方法