### PR TITLE
fix(docker): macos unable to make up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
   # ============================================================================
   openclaw-gateway:
     <<: *openclaw-common
-    # user: "0:0" # Run as root to fix permissions - disabled due to macOS Docker limitations
+    user: "0:0" # Run as root to fix permissions - enabled to fix EACCES
     container_name: openclaw-gateway
     ports:
       - "127.0.0.1:18789:18789"
@@ -122,6 +122,8 @@ services:
       - openclaw-node-modules:/app/node_modules:rw
       - openclaw-go-mod:/home/node/go/pkg/mod:rw
       - openclaw-playwright-cache:/home/node/.cache/ms-playwright:rw
+      # Mount local entrypoint to apply fixes without rebuilding
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro
       # -------------------------------------------------------------------------
       # 🔌 添加额外挂载点 (Extend with custom mounts)
       # -------------------------------------------------------------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,8 +36,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
     
     # If still missing, run official setup
     if [ ! -f "$CONFIG_FILE" ]; then
-        echo "--> Running official OpenClaw setup (non-interactive)..."
-        run_as_node openclaw setup --non-interactive
+        echo "--> Running official OpenClaw onboarding (non-interactive)..."
+        run_as_node openclaw onboard --non-interactive --accept-risk
     fi
 fi
 


### PR DESCRIPTION
fix 2 onboarding issue

```
==> Initializing fresh OpenClaw environment...
--> Copying initial configuration from seed...
--> Running official OpenClaw setup (non-interactive)...
Non-interactive onboarding requires explicit risk acknowledgement.
Read: https://docs.openclaw.ai/security
Re-run with: openclaw onboard --non-interactive --accept-risk ...
```

```
==> Initializing fresh OpenClaw environment...
--> Copying initial configuration from seed...
--> Running official OpenClaw onboarding (non-interactive)...
Error: EACCES: permission denied, open '/home/node/.openclaw/openclaw.json.21.926ef665-db51-47f8-85e1-958b7cdb8a8c.tmp'
```