### PR TITLE
feat(env): 添加 OPENCLAW_ALLOWED_ORIGINS 环境变量配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ OPENCLAW_GATEWAY_BIND=lan
 # Gateway 访问 Token (留空则安装时自动生成)
 OPENCLAW_GATEWAY_TOKEN=
 
+# Gateway 允许的 Origins (JSON 数组)
+OPENCLAW_ALLOWED_ORIGINS='["http://127.0.0.1:18789"]'
+
 # ─────────────────────────────────────────────────────────────────
 # 代理与镜像配置
 # ─────────────────────────────────────────────────────────────────

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ fi
 if [ -f "$CONFIG_FILE" ]; then
     run_as_node openclaw config set gateway.mode local --strict-json >/dev/null 2>&1 || true
     run_as_node openclaw config set gateway.bind lan --strict-json >/dev/null 2>&1 || true
-    run_as_node openclaw config set gateway.controlUi.allowedOrigins '["http://127.0.0.1:18789"]' --strict-json >/dev/null 2>&1 || true
+    run_as_node openclaw config set gateway.controlUi.allowedOrigins "${OPENCLAW_ALLOWED_ORIGINS:-[\"http://127.0.0.1:18789\"]}" --strict-json >/dev/null 2>&1 || true
 fi
 
 # 4. Execute CMD


### PR DESCRIPTION
支持通过环境变量 OPENCLAW_ALLOWED_ORIGINS 动态配置网关控制 UI 的允许来源，提升部署灵活性。默认值保持为 ["http://127.0.0.1:18789"]。