### PR TITLE
fix(ci): pass tool versions via build-args to avoid GitHub API rate limiting

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,9 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       should_build: ${{ steps.check.outputs.should_build }}
       image_name: ${{ steps.info.outputs.image_name }}
+      gh_version: ${{ steps.versions.outputs.gh_version }}
+      yq_version: ${{ steps.versions.outputs.yq_version }}
+      lg_version: ${{ steps.versions.outputs.lg_version }}
     steps:
       - name: Fetch repository info & version
         id: version
@@ -45,12 +48,35 @@ jobs:
           # 使用 GH_TOKEN 避免 API 速率限制
           RESPONSE=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/openclaw/openclaw/releases/latest")
           VERSION=$(echo "$RESPONSE" | jq -r '.tag_name')
-          
+
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             echo "::warning title=API Error::Failed to fetch latest release, falling back to v0.0.0"
             VERSION="v0.0.0"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Fetch tool versions (gh, yq, lazygit)
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 使用 GH_TOKEN 避免 API 速率限制
+          # GitHub CLI
+          GH_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/cli/cli/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+          echo "gh_version=${GH_VERSION}" >> $GITHUB_OUTPUT
+
+          # yq
+          YQ_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/mikefarah/yq/releases/latest" | jq -r '.tag_name')
+          echo "yq_version=${YQ_VERSION}" >> $GITHUB_OUTPUT
+
+          # lazygit
+          LG_VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+          echo "lg_version=${LG_VERSION}" >> $GITHUB_OUTPUT
+
+          echo "Fetched versions: gh=${GH_VERSION}, yq=${YQ_VERSION}, lg=${LG_VERSION}"
 
       - name: Normalize Image Name
         id: info
@@ -158,6 +184,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GH_VERSION=${{ needs.prepare.outputs.gh_version }}
+            YQ_VERSION=${{ needs.prepare.outputs.yq_version }}
+            LG_VERSION=${{ needs.prepare.outputs.lg_version }}
 
   # 核心构建阶段 - 变体镜像 (Go, Java, Office)
   build-variants:

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ ARG INSTALL_BROWSER=1
 ARG APT_MIRROR=deb.debian.org
 ARG NPM_MIRROR=
 ARG PYTHON_MIRROR=
+# GitHub CLI, yq, lazygit 版本 (通过 CI 传入以避免 API 速率限制)
+ARG GH_VERSION=
+ARG YQ_VERSION=
+ARG LG_VERSION=
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -92,10 +96,12 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
-# GitHub CLI 最新版
+# GitHub CLI (版本通过 build-arg 传入避免 API 限流)
 # ============================================================
 RUN ARCH=$(dpkg --print-architecture) && \
-    GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name' | sed 's/^v//') && \
+    if [ -z "$GH_VERSION" ]; then \
+        GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name' | sed 's/^v//'); \
+    fi && \
     curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb" -o /tmp/gh.deb && \
     apt-get update && apt-get install -y /tmp/gh.deb && \
     rm /tmp/gh.deb && \
@@ -103,19 +109,23 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # ============================================================
-# 专家工具下载 (uv, yq, just, lazygit)
+# 专家工具下载 (uv, yq, just, lazygit) (版本通过 build-arg 传入避免 API 限流)
 # ============================================================
 RUN ARCH=$(dpkg --print-architecture) && \
     # uv (Python 极速版)
     curl -fsSL https://astral.sh/uv/install.sh | sh && \
     # yq (YAML 专家)
-    YQ_VERSION=$(curl -fsSL https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name') && \
+    if [ -z "$YQ_VERSION" ]; then \
+        YQ_VERSION=$(curl -fsSL https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name'); \
+    fi && \
     curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq && \
     # just (任务运行器)
     curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin && \
     # lazygit (Git TUI)
-    LG_VERSION=$(curl -fsSL https://api.github.com/repos/jesseduffield/lazygit/releases/latest | jq -r '.tag_name' | sed 's/^v//') && \
+    if [ -z "$LG_VERSION" ]; then \
+        LG_VERSION=$(curl -fsSL https://api.github.com/repos/jesseduffield/lazygit/releases/latest | jq -r '.tag_name' | sed 's/^v//'); \
+    fi && \
     curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LG_VERSION}/lazygit_${LG_VERSION}_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin lazygit
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Pass GitHub CLI, yq, and lazygit versions as build arguments from CI to avoid rate limiting during Docker build
- Add fetch tool versions step in CI prepare phase using `GH_TOKEN` authentication
- Maintain backward compatibility: local builds still work by falling back to dynamic version fetch

## Problem
CI was failing with exit code 22 when Docker tried to fetch latest tool versions via GitHub API without authentication. This is because unauthenticated requests are limited to 60/hour, and the 3 API calls during build could exceed this limit.

## Solution
- Move version fetching to CI prepare phase where `GH_TOKEN` is available
- Pass versions as `build-args` to docker build-push-action
- Update Dockerfile to use passed versions or fallback to dynamic fetch

## Test plan
- [ ] Trigger CI build and verify it completes successfully
- [ ] Verify all three tools (gh, yq, lazygit) are installed with correct versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)